### PR TITLE
ある一定のルールで運行している電車の時刻表を算出する機能

### DIFF
--- a/user/h5y1m141/lib/timetable/base_start_time.rb
+++ b/user/h5y1m141/lib/timetable/base_start_time.rb
@@ -1,0 +1,23 @@
+require 'time'
+class BaseStartTime
+  attr_accessor :base_times
+
+  def initialize(args)
+    @base_times = args[:base_times]
+    @start_time = args[:start_time]
+  end
+
+  def start_time_minute
+    Time.parse(@start_time).min
+  end
+
+  def prepare
+    target = @base_times.select do |base_time|
+      base_time >= start_time_minute
+    end
+    minute = target.empty? ? 0 : target.first
+    hour = Time.parse(@start_time).hour
+    hour = target.empty? ? hour + 1 : hour
+    Time.new(2018, 1, 1, hour, minute)
+  end
+end

--- a/user/h5y1m141/lib/timetable/express_timetable.rb
+++ b/user/h5y1m141/lib/timetable/express_timetable.rb
@@ -1,0 +1,40 @@
+require './lib/timetable/timetable'
+require './lib/timetable/base_start_time'
+class ExpressTimetable < Timetable
+  def initialize(start_time)
+    @base_start_at_times = [15, 35, 55]
+    @train_running_duration = 60 * 2
+    @stop_station_duration = 60 * 1
+    super
+  end
+
+  def prepare(station_list)
+    result = []
+    current = detect_start_time
+    station_list.each do |station|
+      if station[:id] == 'SS0'
+        result.push({ station: station, arrive_at: current, start_at: current })
+      else
+        arrive_at = current + train_running_duration
+        waiting_time = station[:express_stop] ? stop_station_duration : 0
+        start_at = arrive_at + waiting_time
+        result.push({ station: station, arrive_at: arrive_at, start_at: start_at })
+        current = start_at
+      end
+    end
+    result
+  end
+
+  def start_time_minute
+    super
+  end
+
+  def detect_start_time
+    arguments = {
+      start_time: @start_time,
+      base_times: @base_start_at_times
+    }
+    base_time = BaseStartTime.new(arguments)
+    base_time.prepare
+  end
+end

--- a/user/h5y1m141/lib/timetable/express_train.rb
+++ b/user/h5y1m141/lib/timetable/express_train.rb
@@ -1,0 +1,30 @@
+require './lib/timetable/train'
+require './lib/timetable/express_timetable'
+class ExpressTrain < Train
+  def initialize(args)
+    super
+    @timetable = ExpressTimetable.new(start_time)
+  end
+  
+  def stop_stations
+    express_stop_names
+  end
+
+  def timetable_list
+    result = timetable.prepare(station_list).map do |r|
+      target = r[:station][:id] == 'SS21' ? r[:arrive_at] : r[:start_at]
+      format_datetime(target)
+    end
+    result
+  end
+
+  def format_datetime(target)
+    target.strftime('%H:%M')
+  end
+
+  private
+
+  def express_stop_names
+    station_list.select { |station| station[:express_stop]}
+  end
+end

--- a/user/h5y1m141/lib/timetable/local_timetable.rb
+++ b/user/h5y1m141/lib/timetable/local_timetable.rb
@@ -1,0 +1,57 @@
+require './lib/timetable/timetable'
+require './lib/timetable/base_start_time'
+class LocalTimetable < Timetable
+  attr_reader :waiting_express_stations
+
+  def initialize(start_time)
+    super
+    @start_time = start_time
+    @base_start_at_times = [0, 10, 20, 30, 40, 50]
+    @train_running_duration = 60 * 3
+    @stop_station_duration = 60 * 1
+    @current = detect_start_time
+    @waiting_express_stations = detect_stations_for_waiting_express
+  end
+
+  def prepare(station_list)
+    result = []
+    station_list.each do |station|
+      if station[:id] == 'SS0'
+        result.push({ station: station, arrive_at: @current, start_at: @current })
+      else
+        arrive_at = @current + train_running_duration
+        start_at = arrive_at + calcuate_stop_duration(station)
+        result.push({ station: station, arrive_at: arrive_at, start_at: start_at })
+        @current = start_at
+      end
+    end
+    result
+  end
+
+  def calcuate_stop_duration(station)
+    base_time = stop_station_duration
+    waiting_express_stations.include?(station[:id]) ? base_time + 60 * 1 : base_time
+  end
+
+  def start_time_minute
+    super
+  end
+
+  def detect_start_time
+    arguments = {
+      start_time: @start_time,
+      base_times: @base_start_at_times
+    }
+    base_time = BaseStartTime.new(arguments)
+    base_time.prepare
+  end
+
+  def detect_stations_for_waiting_express
+    # 後続の急行がある場合
+    if [10, 30, 50].include?(@current.min)
+      ['SS3']
+    else
+      ['SS9']
+    end
+  end
+end

--- a/user/h5y1m141/lib/timetable/local_train.rb
+++ b/user/h5y1m141/lib/timetable/local_train.rb
@@ -1,0 +1,32 @@
+require './lib/timetable/train'
+require './lib/timetable/local_timetable'
+class LocalTrain < Train
+  attr_reader :timetable
+
+  def initialize(args)
+    super
+    @timetable = LocalTimetable.new(start_time)
+  end
+
+  def stop_stations
+    local_stop_names
+  end
+
+  def timetable_list
+    result = timetable.prepare(station_list).map do |r|
+      target = r[:station][:id] == 'SS21' ? r[:arrive_at] : r[:start_at]
+      format_datetime(target)
+    end
+    result
+  end
+
+  def format_datetime(target)
+    target.strftime('%H:%M')
+  end
+
+  private
+
+  def local_stop_names
+    station_list.select { |station| station[:local_stop]}
+  end
+end

--- a/user/h5y1m141/lib/timetable/station.rb
+++ b/user/h5y1m141/lib/timetable/station.rb
@@ -1,0 +1,43 @@
+class Station
+  attr_reader :seibu_shinjuku_list
+  def initialize
+    @seibu_shinjuku_list = [
+      { id: 'SS0', name: '西武新宿 せいぶしんじゅく', express_stop: true, local_stop: true },
+      { id: 'SS1', name: '高田馬場 たかだのばば', express_stop: true, local_stop: true },
+      { id: 'SS2', name: '下落合 しもおちあい', express_stop: false, local_stop: true },
+      { id: 'SS3', name: '中井 なかい', express_stop: false, local_stop: true },
+      { id: 'SS4', name: '新井薬師前 あらいやくしまえ', express_stop: false, local_stop: true },
+      { id: 'SS5', name: '沼袋 ぬまぶくろ', express_stop: false, local_stop: true },
+      { id: 'SS6', name: '野方 のがた', express_stop: false, local_stop: true },
+      { id: 'SS7', name: '都立家政 とりつかせい', express_stop: false, local_stop: true },
+      { id: 'SS8', name: '鷺ノ宮 さぎのみや', express_stop: true, local_stop: true },
+      { id: 'SS9', name: '下井草 しもいぐさ', express_stop: false, local_stop: true },
+      { id: 'SS10', name: '井荻 いおぎ', express_stop: false, local_stop: true },
+      { id: 'SS11', name: '上井草 かみいぐさ', express_stop: false, local_stop: true },
+      { id: 'SS12', name: '上石神井 かみしゃくじい', express_stop: true, local_stop: true },
+      { id: 'SS13', name: '武蔵関 むさしせき', express_stop: false, local_stop: true },
+      { id: 'SS14', name: '東伏見 ひがしふしみ', express_stop: false, local_stop: true },
+      { id: 'SS15', name: '西武柳沢 せいぶやぎさわ', express_stop: false, local_stop: true },
+      { id: 'SS16', name: '田無 たなし', express_stop: true, local_stop: true },
+      { id: 'SS17', name: '花小金井 はなこがねい', express_stop: true, local_stop: true },
+      { id: 'SS18', name: '小平 こだいら', express_stop: true, local_stop: true },
+      { id: 'SS19', name: '久米川 くめがわ', express_stop: true, local_stop: true },
+      { id: 'SS20', name: '東村山 ひがしむらやま', express_stop: true, local_stop: true },
+      { id: 'SS21', name: '所沢 ところざわ', express_stop: true, local_stop: true }
+    ]
+  end
+
+  def express_stop_names
+    fetch_names(:express_stop)
+  end
+
+  def local_stop_names
+    fetch_names(:local_stop)
+  end
+
+  private
+
+  def fetch_names(type)
+    seibu_shinjuku_list.select { |list| list[type] }
+  end
+end

--- a/user/h5y1m141/lib/timetable/timetable.rb
+++ b/user/h5y1m141/lib/timetable/timetable.rb
@@ -1,0 +1,19 @@
+require 'time'
+class Timetable
+  attr_reader :start_time, :base_start_at_times, :train_running_duration,
+              :stop_station_duration
+  attr_accessor :current
+
+  def initialize(start_time)
+    @start_time = start_time
+    @current = Time.new(2018, 1, 1, 0, 0)
+  end
+
+  def prepare
+    raise NotImplementedError
+  end
+
+  def detect_start_time
+    raise NotImplementedError
+  end
+end

--- a/user/h5y1m141/lib/timetable/train.rb
+++ b/user/h5y1m141/lib/timetable/train.rb
@@ -1,0 +1,23 @@
+require './lib/timetable/station'
+class Train
+  attr_accessor :start_time, :type, :time_to_next
+  attr_reader :timetable, :station_list
+
+  def initialize(args)
+    station = Station.new
+    @start_time = args[:start_time]
+    @station_list = station.seibu_shinjuku_list
+  end
+
+  def stop_stations
+    raise NotImplementedError
+  end
+
+  def timetable_list
+    raise NotImplementedError
+  end
+
+  def show_timetable
+    raise NotImplementedError
+  end
+end

--- a/user/h5y1m141/main.rb
+++ b/user/h5y1m141/main.rb
@@ -1,0 +1,6 @@
+require './lib/timetable/local_train'
+require './lib/timetable/express_train'
+local_train = LocalTrain.new(start_time: '11:09')
+express_train = ExpressTrain.new(start_time: '11:02')
+puts "各駅停車の時刻表\n#{local_train.timetable_list}"
+puts "急行の時刻表\n#{express_train.timetable_list}"

--- a/user/h5y1m141/test/timetable/express_timetable_test.rb
+++ b/user/h5y1m141/test/timetable/express_timetable_test.rb
@@ -1,0 +1,31 @@
+require 'minitest/autorun'
+require 'time'
+require './lib/timetable/station'
+require './lib/timetable/timetable'
+require './lib/timetable/express_timetable'
+class ExpressTimetableTest < MiniTest::Unit::TestCase
+  def setup
+    station = Station.new
+    @station_list = station.seibu_shinjuku_list
+    @express_timetable = ExpressTimetable.new('11:09')
+  end
+
+  def test_prepare
+    list = @express_timetable.prepare(@station_list)
+    station_ss3 = list.select {|target| target[:station][:id] == 'SS3'}.first
+    station_ss4 = list.select {|target| target[:station][:id] == 'SS4'}.first
+    station_ss9 = list.select {|target| target[:station][:id] == 'SS9'}.first
+    station_ss10 = list.select {|target| target[:station][:id] == 'SS10'}.first
+    station_ss21 = list.select {|target| target[:station][:id] == 'SS21'}.first
+    assert_equal(22, station_ss3[:start_at].min)
+    assert_equal(24, station_ss4[:start_at].min)
+    assert_equal(35, station_ss9[:start_at].min)
+    assert_equal(37, station_ss10[:start_at].min)
+    assert_equal(5, station_ss21[:arrive_at].min)
+  end
+
+  def test_start_time_minute
+    target_minute = @express_timetable.detect_start_time.min
+    assert_equal(15, target_minute)
+  end
+end

--- a/user/h5y1m141/test/timetable/express_train_test.rb
+++ b/user/h5y1m141/test/timetable/express_train_test.rb
@@ -1,0 +1,22 @@
+require 'minitest/autorun'
+require './lib/timetable/station'
+require './lib/timetable/timetable'
+require './lib/timetable/express_timetable'
+require './lib/timetable/express_train'
+class ExpressTrainTest < MiniTest::Unit::TestCase
+  def setup
+    station = Station.new
+    @station_list = station.seibu_shinjuku_list
+    @express_train = ExpressTrain.new(start_time: '11:09')
+  end
+
+  def test_stop_stations
+    stations = @express_train.stop_stations
+    station_ss1 = stations.select {|target| target[:id] == 'SS1' }.first
+    station_ss3 = stations.select {|target| target[:id] == 'SS3' }.first
+    station_ss21 = stations.select {|target| target[:id] == 'SS21' }.first
+    assert_equal('SS1', station_ss1[:id])
+    assert_equal(true, station_ss3.nil?)
+    assert_equal('SS21', station_ss21[:id])
+  end
+end

--- a/user/h5y1m141/test/timetable/local_timetable_test.rb
+++ b/user/h5y1m141/test/timetable/local_timetable_test.rb
@@ -1,0 +1,66 @@
+require 'minitest/autorun'
+require 'time'
+require './lib/timetable/station'
+require './lib/timetable/timetable'
+require './lib/timetable/local_timetable'
+class LocalTimetableTest < MiniTest::Unit::TestCase
+  def setup
+    station = Station.new
+    @station_list = station.seibu_shinjuku_list
+    @local_timetable = LocalTimetable.new('11:09')
+  end
+
+  def test_prepare
+    list = @local_timetable.prepare(@station_list)
+    station_ss3 = list.select {|target| target[:station][:id] == 'SS3'}.first
+    station_ss4 = list.select {|target| target[:station][:id] == 'SS4'}.first
+    station_ss9 = list.select {|target| target[:station][:id] == 'SS9'}.first
+    station_ss10 = list.select {|target| target[:station][:id] == 'SS10'}.first
+    station_ss21 = list.select {|target| target[:station][:id] == 'SS21'}.first
+    assert_equal(23, station_ss3[:start_at].min)
+    assert_equal(27, station_ss4[:start_at].min)
+    assert_equal(47, station_ss9[:start_at].min)
+    assert_equal(51, station_ss10[:start_at].min)
+    assert_equal(34, station_ss21[:arrive_at].min)
+  end
+
+  def test_calcuate_stop_duration
+    calcuate_result1 = @local_timetable.calcuate_stop_duration(@station_list[1])
+    calcuate_result2 = @local_timetable.calcuate_stop_duration(@station_list[3])
+    calcuate_result3 = @local_timetable.calcuate_stop_duration(@station_list[9])
+    assert_equal(60, calcuate_result1)
+    assert_equal(120, calcuate_result2)
+    assert_equal(60, calcuate_result3)
+  end
+
+  def test_start_time_minute
+    target_minute = @local_timetable.detect_start_time.min
+    assert_equal(10, target_minute)
+  end
+
+  def test_detect_start_time
+    target_minute = @local_timetable.detect_start_time.min
+    assert_equal(10, target_minute)
+  end
+
+  def test_detect_stations_for_waiting_express
+    local_timetable1 = LocalTimetable.new('11:00')
+    local_timetable2 = LocalTimetable.new('11:09')
+    local_timetable3 = LocalTimetable.new('11:29')
+    local_timetable4 = LocalTimetable.new('11:30')
+    local_timetable5 = LocalTimetable.new('11:31')
+    local_timetable6 = LocalTimetable.new('11:59')
+    target1 = local_timetable1.detect_stations_for_waiting_express
+    target2 = local_timetable2.detect_stations_for_waiting_express
+    target3 = local_timetable3.detect_stations_for_waiting_express
+    target4 = local_timetable4.detect_stations_for_waiting_express
+    target5 = local_timetable5.detect_stations_for_waiting_express
+    target6 = local_timetable6.detect_stations_for_waiting_express
+    assert_equal(['SS9'], target1)
+    assert_equal(['SS3'], target2)
+    assert_equal(['SS3'], target3)
+    assert_equal(['SS3'], target4)
+    assert_equal(['SS9'], target5)
+    assert_equal(['SS9'], target6)
+  end
+end

--- a/user/h5y1m141/test/timetable/local_train_test.rb
+++ b/user/h5y1m141/test/timetable/local_train_test.rb
@@ -1,0 +1,20 @@
+require 'minitest/autorun'
+require './lib/timetable/station'
+require './lib/timetable/timetable'
+require './lib/timetable/local_timetable'
+require './lib/timetable/local_train'
+class LocalTrainTest < MiniTest::Unit::TestCase
+  def setup
+    station = Station.new
+    @station_list = station.seibu_shinjuku_list
+    @local_train = LocalTrain.new(start_time: '11:09')
+  end
+
+  def test_stop_stations
+    stations = @local_train.stop_stations
+    station_ss1 = stations.select {|target| target[:id] == 'SS1' }.first
+    station_ss21 = stations.select {|target| target[:id] == 'SS21' }.first
+    assert_equal('SS1', station_ss1[:id])
+    assert_equal('SS21', station_ss21[:id])
+  end
+end


### PR DESCRIPTION
## このPRについて

[こちらの仕様](https://github.com/chooyan-eng/code-your-ruby/blob/master/specification/timetable.md)の処理を実装しました

## 実行結果

```sh
cd user/h5y1m141
ruby ./main.rb
```

上記実行結果は以下のように表示されます

```
各駅停車の時刻表
["11:10", "11:14", "11:18", "11:23", "11:27", "11:31", "11:35", "11:39", "11:43", "11:47", "11:51", "11:55", "11:59", "12:03", "12:07", "12:11", "12:15", "12:19", "12:23", "12:27", "12:31", "12:34"]
急行の時刻表
["11:15", "11:18", "11:20", "11:22", "11:24", "11:26", "11:28", "11:30", "11:33", "11:35", "11:37", "11:39", "11:42", "11:44", "11:46", "11:48", "11:51", "11:54", "11:57", "12:00", "12:03", "12:05"]
```

## テストについて

MiniTestは使ったことがないのでこんな書き方で良いのかどうか悩みながらも一応

- 各駅停車
- 急行停車

の時刻表算出時のベースになりそうなメソッドに対して網羅しました。

## 参考

コード読む上で参考情報を記載しておきます

### それぞれのクラスの役割

各駅停車の処理を例にシーケンス図まとめました。
  
![timetable](https://user-images.githubusercontent.com/950924/34762135-ff260f30-f629-11e7-9d32-2c674f1372ea.png)

### 実装上の工夫点

仕様理解が難しい（特に各駅停車が急行通過待ちをするあたり）というのが最初の印象だったので、

```ruby
  def detect_stations_for_waiting_express
    # 後続の急行がある場合
    if [10, 30, 50].include?(@current.min)
      ['SS3']
    else
      ['SS9']
    end
  end
```

の所でそこをうまく吸収できるようにあらかじめ実装してみました

